### PR TITLE
[pre] maybe typo privacyUrl -> privacyLink

### DIFF
--- a/dev-docs/show-native-ads.md
+++ b/dev-docs/show-native-ads.md
@@ -94,7 +94,7 @@ Specific bidders may not support all of the fields listed below or may return di
 | `image`       | A picture that is associated with the brand, or grabs the user's attention.          | `hb_native_image`     |
 | `clickUrl`    | Where the user will end up if they click the ad.                                     | `hb_native_linkurl`   |
 | `displayUrl`  | Text that can be displayed instead of the raw click URL. e.g, "Example.com/Specials" | `hb_native_displayUrl`|
-| `privacyUrl`  | Link to the Privacy Policy of the Buyer, e.g. http://example.com/privacy             | `hb_native_privacy`   |
+| `privacyLink` | Link to the Privacy Policy of the Buyer, e.g. http://example.com/privacy             | `hb_native_privacy`   |
 | `cta`         | *Call to Action* text, e.g., "Click here for more information".                      | `hb_native_cta`       |
 | `rating`      | Rating information, e.g., "4" out of 5.                                              | `hb_native_rating`    |
 | `downloads`   | The total downloads of the advertised application/product                            | `hb_native_downloads` |
@@ -147,7 +147,7 @@ pbjs.addAdUnits({
             clickUrl: {
                 required: true
             },
-            privacyUrl: {
+            privacyLink: {
                 required: false
             },
             body: {


### PR DESCRIPTION
`privacyUrl` is written in docs, but `privacyLink` in source code. ↓

https://github.com/prebid/Prebid.js/blob/c060a5ce9087f48f257c4a383f854e989e49dab4/src/constants.json#L74